### PR TITLE
Feature update: send results to server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,8 @@ sysinfo.txt
 # Crashlytics generated file
 crashlytics-build.properties
 
+
+# Results generated while testing
+Questionnaires/Questionnaire/Assets/Questionnaires/Data/Answers/testdev
+Questionnaires/Questionnaire/Assets/Questionnaires/Data/Answers/testdev.meta
+

--- a/Questionnaires/Questionnaire/Assets/Questionnaires/Data/Answers/testdev.meta
+++ b/Questionnaires/Questionnaire/Assets/Questionnaires/Data/Answers/testdev.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 889ddd47f1a9248bf8de1fa49096fe3d
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Questionnaires/Questionnaire/Assets/Questionnaires/Scenes/SampleScene.unity
+++ b/Questionnaires/Questionnaire/Assets/Questionnaires/Scenes/SampleScene.unity
@@ -474,7 +474,7 @@ PrefabInstance:
     - target: {fileID: 8697000387260259616, guid: 93494b0f3d397d74ba1458871f004384,
         type: 3}
       propertyPath: SoundOnOff
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8697000387260259616, guid: 93494b0f3d397d74ba1458871f004384,
         type: 3}
@@ -541,6 +541,21 @@ PrefabInstance:
       propertyPath: alsoSaveToServer
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 8697000387260259616, guid: 93494b0f3d397d74ba1458871f004384,
+        type: 3}
+      propertyPath: AlsoConsolidateResults
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8697000387260259616, guid: 93494b0f3d397d74ba1458871f004384,
+        type: 3}
+      propertyPath: SoundClipForHovering
+      value: 
+      objectReference: {fileID: 8300000, guid: d7d08c266925c5446947a004fde53aa0, type: 3}
+    - target: {fileID: 8697000387260259616, guid: 93494b0f3d397d74ba1458871f004384,
+        type: 3}
+      propertyPath: SoundClipForSelecting
+      value: 
+      objectReference: {fileID: 8300000, guid: 7b660b21fad7af34e806c3f3c4eb8868, type: 3}
     - target: {fileID: 8697000387260259617, guid: 93494b0f3d397d74ba1458871f004384,
         type: 3}
       propertyPath: m_Name
@@ -714,6 +729,26 @@ PrefabInstance:
     - target: {fileID: 8697000388396706263, guid: 93494b0f3d397d74ba1458871f004384,
         type: 3}
       propertyPath: alsoSaveToServer
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8697000388396706263, guid: 93494b0f3d397d74ba1458871f004384,
+        type: 3}
+      propertyPath: UseGlobalPath
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8697000388396706263, guid: 93494b0f3d397d74ba1458871f004384,
+        type: 3}
+      propertyPath: TargetURI
+      value: http://localhost/test-vr-questionnaire/survey-results.php
+      objectReference: {fileID: 0}
+    - target: {fileID: 8697000388396706263, guid: 93494b0f3d397d74ba1458871f004384,
+        type: 3}
+      propertyPath: SaveToServer
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8697000388396706263, guid: 93494b0f3d397d74ba1458871f004384,
+        type: 3}
+      propertyPath: SaveToLocal
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []

--- a/Questionnaires/Questionnaire/Assets/Questionnaires/Scenes/SampleScene.unity
+++ b/Questionnaires/Questionnaire/Assets/Questionnaires/Scenes/SampleScene.unity
@@ -303,7 +303,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1383332835}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.5375924, y: 0.06452304, z: 5.2643194}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -534,7 +534,7 @@ PrefabInstance:
     - target: {fileID: 8697000387260259616, guid: 93494b0f3d397d74ba1458871f004384,
         type: 3}
       propertyPath: targetURI
-      value: http://localhost/test-vr-questionnaire/test.php
+      value: http://localhost/_test/test.php
       objectReference: {fileID: 0}
     - target: {fileID: 8697000387260259616, guid: 93494b0f3d397d74ba1458871f004384,
         type: 3}
@@ -705,6 +705,16 @@ PrefabInstance:
         type: 3}
       propertyPath: StorePath
       value: /Questionnaires/Data/Answers/
+      objectReference: {fileID: 0}
+    - target: {fileID: 8697000388396706263, guid: 93494b0f3d397d74ba1458871f004384,
+        type: 3}
+      propertyPath: targetURI
+      value: http://localhost/test-vr-questionnaire/test.php
+      objectReference: {fileID: 0}
+    - target: {fileID: 8697000388396706263, guid: 93494b0f3d397d74ba1458871f004384,
+        type: 3}
+      propertyPath: alsoSaveToServer
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 93494b0f3d397d74ba1458871f004384, type: 3}

--- a/Questionnaires/Questionnaire/Assets/Questionnaires/Scenes/SampleScene.unity
+++ b/Questionnaires/Questionnaire/Assets/Questionnaires/Scenes/SampleScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0.18028334, g: 0.2257134, b: 0.30692226, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028355, g: 0.22571374, b: 0.30692255, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -531,6 +531,16 @@ PrefabInstance:
       propertyPath: soundClipForSelecting
       value: 
       objectReference: {fileID: 8300000, guid: 7b660b21fad7af34e806c3f3c4eb8868, type: 3}
+    - target: {fileID: 8697000387260259616, guid: 93494b0f3d397d74ba1458871f004384,
+        type: 3}
+      propertyPath: targetURI
+      value: http://localhost/test-vr-questionnaire/test.php
+      objectReference: {fileID: 0}
+    - target: {fileID: 8697000387260259616, guid: 93494b0f3d397d74ba1458871f004384,
+        type: 3}
+      propertyPath: alsoSaveToServer
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 8697000387260259617, guid: 93494b0f3d397d74ba1458871f004384,
         type: 3}
       propertyPath: m_Name

--- a/Questionnaires/Questionnaire/Assets/Questionnaires/Scripts/Export/ExportToCSV.cs
+++ b/Questionnaires/Questionnaire/Assets/Questionnaires/Scripts/Export/ExportToCSV.cs
@@ -24,13 +24,17 @@ namespace VRQuestionnaireToolkit
 {
     public class ExportToCSV : MonoBehaviour
     {
-        public string StorePath;
         public string FileName;
         public string Delimiter;
+
+        [Header("Configure if you want to save the results to local storage:")]
+        [Tooltip("Save results locally on this device.")]
+        public bool SaveToLocal = true;
+        public string StorePath;
         public bool UseGlobalPath;
 
-        [Header("If you want to save the results to a server:")]
-        public bool AlsoSaveToServer = false;
+        [Header("Configure if you want to save the results to remote server:")]
+        public bool SaveToServer = false;
         [Tooltip("The target URI to send the results to")]
         public string TargetURI = "http://www.example-server.com/survey-results.php";
 
@@ -272,7 +276,7 @@ namespace VRQuestionnaireToolkit
             outStream.Close();
 
             /* SENDING RESULTS TO SERVER */
-            if (AlsoSaveToServer)
+            if (SaveToServer)
             {
                 string allText = System.IO.File.ReadAllText(_path);
                 StartCoroutine(SendToServer(TargetURI, _completeFileName, allText));
@@ -318,7 +322,7 @@ namespace VRQuestionnaireToolkit
                     Debug.Log(ex.Message);
                 }
 
-                if (AlsoSaveToServer)
+                if (SaveToServer)
                 {
                     string allText = System.IO.File.ReadAllText(_path_allResults);
                     StartCoroutine(SendToServer(TargetURI, _completeFileName_allResults, allText));

--- a/Questionnaires/Questionnaire/Assets/Questionnaires/Scripts/Export/ExportToCSV.cs
+++ b/Questionnaires/Questionnaire/Assets/Questionnaires/Scripts/Export/ExportToCSV.cs
@@ -268,10 +268,7 @@ namespace VRQuestionnaireToolkit
             for (int index = 0; index < length; index++)
                 sb.AppendLine(string.Join(Delimiter, output[index]));
 
-            print("Answers stored in path: " + _path);
-            StreamWriter outStream = System.IO.File.CreateText(_path);
-            outStream.WriteLine(sb);
-            outStream.Close();
+            WriteToLocal(_path, sb);
 
             /* SENDING RESULTS TO SERVER */
             if (SaveToServer)
@@ -328,6 +325,14 @@ namespace VRQuestionnaireToolkit
             }
 
             QuestionnaireFinishedEvent.Invoke(); //notify 
+        }
+
+        void WriteToLocal(string localPath, StringBuilder content)
+        {
+            print("Answers stored in path: " + localPath);
+            StreamWriter outStream = System.IO.File.CreateText(localPath);
+            outStream.WriteLine(content);
+            outStream.Close();
         }
 
         /// <summary>

--- a/Questionnaires/Questionnaire/Assets/Questionnaires/Scripts/Export/ExportToCSV.cs
+++ b/Questionnaires/Questionnaire/Assets/Questionnaires/Scripts/Export/ExportToCSV.cs
@@ -268,13 +268,16 @@ namespace VRQuestionnaireToolkit
             for (int index = 0; index < length; index++)
                 sb.AppendLine(string.Join(Delimiter, output[index]));
 
-            WriteToLocal(_path, sb);
+            /* WRITING RESULTS TO LOCAL STORAGE */
+            if (SaveToLocal)
+            {
+                WriteToLocal(_path, sb);
+            }
 
-            /* SENDING RESULTS TO SERVER */
+            /* SENDING RESULTS TO REMOTE SERVER */
             if (SaveToServer)
             {
-                string allText = System.IO.File.ReadAllText(_path);
-                StartCoroutine(SendToServer(TargetURI, _completeFileName, allText));
+                StartCoroutine(SendToServer(TargetURI, _completeFileName, sb.ToString()));
             }
 
             /* CONSOLIDATING RESULTS */

--- a/Questionnaires/Questionnaire/Assets/Questionnaires/Scripts/Export/ExportToCSV.cs
+++ b/Questionnaires/Questionnaire/Assets/Questionnaires/Scripts/Export/ExportToCSV.cs
@@ -129,6 +129,7 @@ namespace VRQuestionnaireToolkit
             for (int i = 1; i < _pageFactory.GetComponent<PageFactory>().NumPages - 1; i++)
                 _pageFactory.GetComponent<PageFactory>().PageList[i].SetActive(true);
 
+            #region CONSTRUCTING RESULTS
             // read participants' responses 
             for (int i = 0; i < _pageFactory.GetComponent<PageFactory>().QuestionList.Count; i++)
             {
@@ -255,6 +256,7 @@ namespace VRQuestionnaireToolkit
                     }
                 }
             }
+            #endregion
 
             // disable all GameObjects (except the last page) 
             for (int i = 1; i < _pageFactory.GetComponent<PageFactory>().NumPages - 1; i++)
@@ -311,6 +313,12 @@ namespace VRQuestionnaireToolkit
             QuestionnaireFinishedEvent.Invoke(); //notify 
         }
 
+        /// <summary>
+        /// Consolidate all results to a StringBuilder, written to be directly written.
+        /// </summary>
+        /// <param name="filepath"></param>
+        /// <param name="newData"></param>
+        /// <returns></returns>
         StringBuilder GetConsolidatedContent(string filepath, string[][] newData)
         {
             StringBuilder sb_all_content = new StringBuilder();
@@ -345,6 +353,11 @@ namespace VRQuestionnaireToolkit
             return sb_all_content;
         }
 
+        /// <summary>
+        /// Write a StringBuilder to a local file.
+        /// </summary>
+        /// <param name="localPath"></param>
+        /// <param name="content"></param>
         void WriteToLocal(string localPath, StringBuilder content)
         {
             print("Answers stored in path: " + localPath);
@@ -389,6 +402,11 @@ namespace VRQuestionnaireToolkit
             }
         }
 
+        /// <summary>
+        /// Check if the provided server URI is valid.
+        /// </summary>
+        /// <param name="uri"></param>
+        /// <returns></returns>
         IEnumerator CheckURIValidity(string uri)
         {
             UnityWebRequest www = new UnityWebRequest(uri);

--- a/Questionnaires/Questionnaire/Assets/Questionnaires/Scripts/Export/ExportToCSV.cs
+++ b/Questionnaires/Questionnaire/Assets/Questionnaires/Scripts/Export/ExportToCSV.cs
@@ -34,8 +34,6 @@ namespace VRQuestionnaireToolkit
         [Tooltip("The target URI to send the results to")]
         public string targetURI = "http://www.example-server.com/survey-results.php";
 
-        private string _path;
-        private string _path_all;
         private List<string[]> _csvRows;
         private GameObject _pageFactory;
         private GameObject _vrQuestionnaireToolkit;
@@ -44,13 +42,13 @@ namespace VRQuestionnaireToolkit
         private string _fileType;
         private string _questionnaireID;
 
-        public enum FileTyps
+        public enum FileType
         {
             Csv,
             Txt
         }
 
-        public FileTyps Filetyp;
+        public FileType Filetype;
 
         public UnityEvent QuestionnaireFinishedEvent;
 
@@ -63,16 +61,12 @@ namespace VRQuestionnaireToolkit
             if (QuestionnaireFinishedEvent == null)
                 QuestionnaireFinishedEvent = new UnityEvent();
 
-            if (Filetyp == 0)
+            if (Filetype == 0)
                 _fileType = "csv";
             else
             {
                 _fileType = "txt";
             }
-
-            // Just for testing
-            if (alsoSaveToServer)
-                StartCoroutine(SendToServer(targetURI, "test test test"));
         }
 
         public void Save()
@@ -252,8 +246,11 @@ namespace VRQuestionnaireToolkit
 
             //-----Processing responses into the specified data format-----//
 
-            _path = _folderPath + "questionnaireID_" + _questionnaireID + "_participantID_" + _studySetup.ParticipantId + "_condition_" + _studySetup.Condition + "_" + FileName + "." + _fileType;
-            _path_all = _folderPath + "questionnaireID_" + _questionnaireID + "_ALL_" + FileName + "." + _fileType;
+            string _completeFileName = "questionnaireID_" + _questionnaireID + "_participantID_" + _studySetup.ParticipantId + "_condition_" + _studySetup.Condition + "_" + FileName + "." + _fileType;
+            string _completeFileName_allResults = "questionnaireID_" + _questionnaireID + "_ALL_" + FileName + "." + _fileType;
+            string _path = _folderPath + _completeFileName;
+            string _path_allResults = _folderPath + _completeFileName_allResults;
+
 
             string[][] output = new string[_csvRows.Count][];
 
@@ -274,6 +271,12 @@ namespace VRQuestionnaireToolkit
             outStream.WriteLine(sb);
             outStream.Close();
 
+            /* SENDING RESULTS TO SERVER */
+            if (alsoSaveToServer)
+            {
+                string allText = System.IO.File.ReadAllText(_path);
+                StartCoroutine(SendToServer(targetURI, _completeFileName, allText));
+            }
 
             /* CONSOLIDATING RESULTS */
             if (_studySetup.AlsoConsolidateResults)
@@ -282,21 +285,21 @@ namespace VRQuestionnaireToolkit
 
                 try
                 {
-                    if (!File.Exists(_path_all)) // if the summary sheet has not been created yet
+                    if (!File.Exists(_path_allResults)) // if the summary sheet has not been created yet
                     {
-                        StreamWriter sw = new StreamWriter(_path_all);
+                        StreamWriter sw = new StreamWriter(_path_allResults);
                         sw.WriteLine(csvTitleRow[0] + Delimiter + csvTitleRow[1] + Delimiter + csvTitleRow[2] + Delimiter + header);
                         for (int row = 1; row < length; row++)
                         {
                             sw.WriteLine(string.Join(Delimiter, output[row]));
                         }
                         sw.Close();
-                        print("Answers consolidated in path: " + _path_all);
+                        print("Answers consolidated in path: " + _path_allResults);
                     }
                     else
                     {
                         StringBuilder sb2 = new StringBuilder();
-                        StreamReader sr = new StreamReader(_path_all);
+                        StreamReader sr = new StreamReader(_path_allResults);
                         sb2.AppendLine(sr.ReadLine() + Delimiter + header);
                         for (int row = 1; row < length; row++)
                         {
@@ -304,15 +307,21 @@ namespace VRQuestionnaireToolkit
                         }
                         sr.Close();
 
-                        StreamWriter sw = System.IO.File.CreateText(_path_all);
+                        StreamWriter sw = System.IO.File.CreateText(_path_allResults);
                         sw.WriteLine(sb2);
                         sw.Close();
-                        print("Answers consolidated in path: " + _path_all);
+                        print("Answers consolidated in path: " + _path_allResults);
                     }
                 }
                 catch (IOException ex)
                 {
                     Debug.Log(ex.Message);
+                }
+
+                if (alsoSaveToServer)
+                {
+                    string allText = System.IO.File.ReadAllText(_path_allResults);
+                    StartCoroutine(SendToServer(targetURI, _completeFileName_allResults, allText));
                 }
             }
 
@@ -327,12 +336,14 @@ namespace VRQuestionnaireToolkit
         /// Post data to a specific server location.
         /// </summary>
         /// <param name="uri"></param>
-        /// <param name="data"></param>
+        /// <param name="filename"></param>
+        /// <param name="inputData"></param>
         /// <returns></returns>
-        IEnumerator SendToServer(string uri, string data)
+        IEnumerator SendToServer(string uri, string filename, string inputData)
         {
             WWWForm form = new WWWForm();
-            form.AddField("unitypost", data);
+            form.AddField("fileName", filename);
+            form.AddField("inputData", inputData);
 
             using (UnityWebRequest www = UnityWebRequest.Post(uri, form))
             {
@@ -345,7 +356,7 @@ namespace VRQuestionnaireToolkit
                 else
                 {
                     string responseText = www.downloadHandler.text;
-                    Debug.Log("Response Text from the server: " + responseText);
+                    Debug.Log("Message from the server: " + responseText);
                 }
             }
         }

--- a/Questionnaires/Questionnaire/Assets/Questionnaires/Scripts/Export/ExportToCSV.cs
+++ b/Questionnaires/Questionnaire/Assets/Questionnaires/Scripts/Export/ExportToCSV.cs
@@ -26,6 +26,12 @@ namespace VRQuestionnaireToolkit
     {
         public string FileName;
         public string Delimiter;
+        public enum FileType
+        {
+            Csv,
+            Txt
+        }
+        public FileType Filetype;
 
         [Header("Configure if you want to save the results to local storage:")]
         [Tooltip("Save results locally on this device.")]
@@ -45,14 +51,6 @@ namespace VRQuestionnaireToolkit
         private string _folderPath;
         private string _fileType;
         private string _questionnaireID;
-
-        public enum FileType
-        {
-            Csv,
-            Txt
-        }
-
-        public FileType Filetype;
 
         public UnityEvent QuestionnaireFinishedEvent;
 

--- a/Questionnaires/Questionnaire/Assets/Questionnaires/Scripts/Export/ExportToCSV.cs
+++ b/Questionnaires/Questionnaire/Assets/Questionnaires/Scripts/Export/ExportToCSV.cs
@@ -30,9 +30,9 @@ namespace VRQuestionnaireToolkit
         public bool UseGlobalPath;
 
         [Header("If you want to save the results to a server:")]
-        public bool alsoSaveToServer = false;
+        public bool AlsoSaveToServer = false;
         [Tooltip("The target URI to send the results to")]
-        public string targetURI = "http://www.example-server.com/survey-results.php";
+        public string TargetURI = "http://www.example-server.com/survey-results.php";
 
         private List<string[]> _csvRows;
         private GameObject _pageFactory;
@@ -272,10 +272,10 @@ namespace VRQuestionnaireToolkit
             outStream.Close();
 
             /* SENDING RESULTS TO SERVER */
-            if (alsoSaveToServer)
+            if (AlsoSaveToServer)
             {
                 string allText = System.IO.File.ReadAllText(_path);
-                StartCoroutine(SendToServer(targetURI, _completeFileName, allText));
+                StartCoroutine(SendToServer(TargetURI, _completeFileName, allText));
             }
 
             /* CONSOLIDATING RESULTS */
@@ -318,10 +318,10 @@ namespace VRQuestionnaireToolkit
                     Debug.Log(ex.Message);
                 }
 
-                if (alsoSaveToServer)
+                if (AlsoSaveToServer)
                 {
                     string allText = System.IO.File.ReadAllText(_path_allResults);
-                    StartCoroutine(SendToServer(targetURI, _completeFileName_allResults, allText));
+                    StartCoroutine(SendToServer(TargetURI, _completeFileName_allResults, allText));
                 }
             }
 

--- a/Questionnaires/Questionnaire/Assets/Questionnaires/Scripts/Export/ExportToCSV.cs
+++ b/Questionnaires/Questionnaire/Assets/Questionnaires/Scripts/Export/ExportToCSV.cs
@@ -29,6 +29,11 @@ namespace VRQuestionnaireToolkit
         public string Delimiter;
         public bool UseGlobalPath;
 
+        [Header("If you want to save the results to a server:")]
+        public bool alsoSaveToServer = false;
+        [Tooltip("The target URI to send the results to")]
+        public string targetURI = "http://www.example-server.com/survey-results.php";
+
         private string _path;
         private string _path_all;
         private List<string[]> _csvRows;
@@ -64,6 +69,10 @@ namespace VRQuestionnaireToolkit
             {
                 _fileType = "txt";
             }
+
+            // Just for testing
+            if (alsoSaveToServer)
+                StartCoroutine(SendToServer(targetURI, "test test test"));
         }
 
         public void Save()
@@ -323,7 +332,7 @@ namespace VRQuestionnaireToolkit
         IEnumerator SendToServer(string uri, string data)
         {
             WWWForm form = new WWWForm();
-            form.AddField("Survey results", data);
+            form.AddField("unitypost", data);
 
             using (UnityWebRequest www = UnityWebRequest.Post(uri, form))
             {
@@ -331,12 +340,12 @@ namespace VRQuestionnaireToolkit
 
                 if (www.isHttpError || www.isNetworkError)
                 {
-                    Debug.LogError(www.error);
+                    Debug.LogError(www.error + "\nPlease check the validity of the server URI.");
                 }
                 else
                 {
                     string responseText = www.downloadHandler.text;
-                    Debug.Log("Response Text from the server = " + responseText);
+                    Debug.Log("Response Text from the server: " + responseText);
                 }
             }
         }

--- a/Questionnaires/Questionnaire/Assets/Questionnaires/Scripts/FeedbackManager.cs
+++ b/Questionnaires/Questionnaire/Assets/Questionnaires/Scripts/FeedbackManager.cs
@@ -9,7 +9,7 @@ namespace VRQuestionnaireToolkit
 {
     public class FeedbackManager : MonoBehaviour
     {        
-        public SteamVR_Action_Vibration hapticAction;
+        public SteamVR_Action_Vibration HapticAction;
 
         // To later access the boolean state of tactile/sound feedback.
         private StudySetup _studySetup;
@@ -19,16 +19,16 @@ namespace VRQuestionnaireToolkit
 
         // A selecting action should trigger the feedback no earlier than 1 second after a hovering feedback is finished.
         // This is to avoid the discomfort when two types of actions are triggered too close to each other.
-        private float feedback_break = 1.0f; // one second
-        private bool flag_isBusy = false;
+        private float _feedbackBreak = 1.0f; // one second
+        private bool _flagIsBusy = false;
 
         void Start()
         {
             GameObject _vrToolkit = GameObject.FindGameObjectWithTag("VRQuestionnaireToolkit");
             _studySetup = _vrToolkit.GetComponent<StudySetup>();
             _audioSource = _studySetup.GetComponent<AudioSource>();
-            _hoverSoundClip = _studySetup.soundClipForHovering;
-            _selectSoundClip = _studySetup.soundClipForSelecting;
+            _hoverSoundClip = _studySetup.SoundClipForHovering;
+            _selectSoundClip = _studySetup.SoundClipForSelecting;
             AddTriggerListener();
         }
 
@@ -36,8 +36,8 @@ namespace VRQuestionnaireToolkit
         {
             try
             {
-                hapticAction.Execute(0, duration, frequency, amplitude, SteamVR_Input_Sources.LeftHand);
-                hapticAction.Execute(0, duration, frequency, amplitude, SteamVR_Input_Sources.RightHand);
+                HapticAction.Execute(0, duration, frequency, amplitude, SteamVR_Input_Sources.LeftHand);
+                HapticAction.Execute(0, duration, frequency, amplitude, SteamVR_Input_Sources.RightHand);
             }
             catch  // If a NullReferenceException is catched, turn off the tactile feedback.
             {
@@ -68,32 +68,32 @@ namespace VRQuestionnaireToolkit
 
         public void OnHovering()
         {
-            CountdownFeedback(feedback_break);
+            CountdownFeedback(_feedbackBreak);
 
             if (_studySetup.ControllerTactileFeedbackOnOff) // If tactile feedback is switched on
             {
-                PulseBothHands(_studySetup.vibratingDurationForHovering, _studySetup.vibratingFrequencyForHovering, _studySetup.vibratingAmplitudeForHovering);
+                PulseBothHands(_studySetup.VibratingDurationForHovering, _studySetup.VibratingFrequencyForHovering, _studySetup.VibratingAmplitudeForHovering);
                 // Debug.Log("Controller vibration on hovering zzz!");
             }
             if (_studySetup.SoundOnOff) // If sound feedback is switched on
             {
-                _audioSource.volume = _studySetup.hoveringVolume;
+                _audioSource.volume = _studySetup.HoveringVolume;
                 _audioSource.PlayOneShot(_hoverSoundClip);
             }
         }
 
         public void OnSelecting()
         {
-            if (!flag_isBusy)
+            if (!_flagIsBusy)
             {
                 if (_studySetup.ControllerTactileFeedbackOnOff) // If tactile feedback is switched on
                 {
-                    PulseBothHands(_studySetup.vibratingDurationForSelecting, _studySetup.vibratingFrequencyForSelecting, _studySetup.vibratingAmplitudeForSelecting);
+                    PulseBothHands(_studySetup.VibratingDurationForSelecting, _studySetup.VibratingFrequencyForSelecting, _studySetup.VibratingAmplitudeForSelecting);
                     // Debug.Log("Controller vibration on selecting zzz!");
                 }
                 if (_studySetup.SoundOnOff) // If sound feedback is switched on
                 {
-                    _audioSource.volume = _studySetup.selectingVolume;
+                    _audioSource.volume = _studySetup.SelectingVolume;
                     _audioSource.PlayOneShot(_selectSoundClip);
                 }
             }
@@ -105,9 +105,9 @@ namespace VRQuestionnaireToolkit
         /// <param name="_interval"></param>
         private async void CountdownFeedback(float _interval)
         {
-            flag_isBusy = true;
+            _flagIsBusy = true;
             await Task.Delay((int)(_interval * 1000));
-            flag_isBusy = false;
+            _flagIsBusy = false;
         }
     }
 }

--- a/Questionnaires/Questionnaire/Assets/Questionnaires/Scripts/StudySetup.cs
+++ b/Questionnaires/Questionnaire/Assets/Questionnaires/Scripts/StudySetup.cs
@@ -31,27 +31,27 @@ namespace VRQuestionnaireToolkit
 
         [Header("Customize feedback parameters on hovering:")]
         [Range(0, 1)]
-        public float vibratingDurationForHovering = 0.05f;
+        public float VibratingDurationForHovering = 0.05f;
         [Range(0, 200)]
-        public float vibratingFrequencyForHovering = 1.0f;
+        public float VibratingFrequencyForHovering = 1.0f;
         [Range(0, 100)]
-        public float vibratingAmplitudeForHovering = 5.0f;
+        public float VibratingAmplitudeForHovering = 5.0f;
         [Tooltip("Choose the audio file to play upon hovering over a button.")]
-        public AudioClip soundClipForHovering;
+        public AudioClip SoundClipForHovering;
         [Range(0.0f, 1.0f)]
-        public float hoveringVolume = 1.0f;
+        public float HoveringVolume = 1.0f;
 
         [Header("Customize feedback parameters on selecting:")]
         [Range(0, 1)]
-        public float vibratingDurationForSelecting = 0.05f;
+        public float VibratingDurationForSelecting = 0.05f;
         [Range(0, 200)]
-        public float vibratingFrequencyForSelecting = 200.0f;
+        public float VibratingFrequencyForSelecting = 200.0f;
         [Range(0, 100)]
-        public float vibratingAmplitudeForSelecting = 1.0f;
+        public float VibratingAmplitudeForSelecting = 1.0f;
         [Tooltip("Choose the audio file to play upon selecting on a button.")]
-        public AudioClip soundClipForSelecting;
+        public AudioClip SoundClipForSelecting;
         [Range(0.0f, 1.0f)]
-        public float selectingVolume = 1.0f;
+        public float SelectingVolume = 1.0f;
 
         private string _path; // file path to write the remembered transform values to
 
@@ -75,8 +75,6 @@ namespace VRQuestionnaireToolkit
             if (ConfigurationMode)
                 SaveCurrentValues();
         }
-
-
 
         /// <summary>
         /// Resize the questionnaire panel by hitting keys + and -.

--- a/Questionnaires/Questionnaire/Assets/Questionnaires/Scripts/StudySetup.cs
+++ b/Questionnaires/Questionnaire/Assets/Questionnaires/Scripts/StudySetup.cs
@@ -53,11 +53,6 @@ namespace VRQuestionnaireToolkit
         [Range(0.0f, 1.0f)]
         public float selectingVolume = 1.0f;
 
-        [Header("If you want to save the results to a server:")]
-        public bool alsoSaveToServer = false;
-        [Tooltip("The target URI to send the results to")]
-        public string targetURI = "http://www.example-server.com/survey-results.php";
-
         private string _path; // file path to write the remembered transform values to
 
         void Start()

--- a/Questionnaires/Questionnaire/Assets/Resources/Templates.meta
+++ b/Questionnaires/Questionnaire/Assets/Resources/Templates.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9df9bb45963414e178140213c1c1c7b2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Questionnaires/Questionnaire/Assets/Resources/Templates/survey-results.php
+++ b/Questionnaires/Questionnaire/Assets/Resources/Templates/survey-results.php
@@ -1,11 +1,11 @@
 <?php
 	// php template for receiving the result data.
 	// place this file under the directory where you want to store the result data on your server.
-	// for customisation, see also ExportToCSV.cs, line 342.
+	// for customisation, see also ExportToCSV.cs.
  
 	$fileName = $_POST["fileName"];
 	$inputData = $_POST["inputData"];
 	$file = fopen($fileName, "w") or die("Unable to open file!");
 	fwrite($file, $inputData);
-	echo "Results written in $fileName.";
+	echo "Results written remotely at $fileName.";
 ?>

--- a/Questionnaires/Questionnaire/Assets/Resources/Templates/survey-results.php
+++ b/Questionnaires/Questionnaire/Assets/Resources/Templates/survey-results.php
@@ -1,0 +1,11 @@
+<?php
+	// php template for receiving the result data.
+	// place this file under the directory where you want to store the result data on your server.
+	// for customisation, see also ExportToCSV.cs, line 342.
+ 
+	$fileName = $_POST["fileName"];
+	$inputData = $_POST["inputData"];
+	$file = fopen($fileName, "w") or die("Unable to open file!");
+	fwrite($file, $inputData);
+	echo "Results written in $fileName.";
+?>

--- a/Questionnaires/Questionnaire/Assets/Resources/Templates/survey-results.php.meta
+++ b/Questionnaires/Questionnaire/Assets/Resources/Templates/survey-results.php.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 26dcb6c4d29cc455e8f8ae2afe5f1032
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Instruction:
1. Copy `survey-results.php` under Assets/Resources/Templates to your server. The survey results will be saved in parallel with it.
2. In SampleScene's architecture, go to VRQuestionnaireToolkit->ExportToCSV
3. In the inspector window, check `Also Save To Server`
4. Replace the `target URI` with your server’s address (e.g. http://www.example-server.com/survey-results.php, http://localhost/survey-results.php)
5. Run the scene.
6. When you hit “Submit” in the end, the survey results will be written both locally on your device and your server. You may check the Unity console for the exact paths where the data are stored.
